### PR TITLE
simplify extra cflags management + report versions

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -51,9 +51,8 @@ if test "$PHP_LIBARCHIVE" != "no"; then
   ])
   CC_FLAG_CHECK([-Wnullability-completeness], [-Wno-nullability-completeness])
 
-  extra_cflags="$cflags_null -fvisibility=hidden"
-  echo "EXTRA_CFLAGS := \$(EXTRA_CFLAGS) $extra_cflags" >> Makefile.fragments
+  extra_cflags="-Wall $cflags_null -fvisibility=hidden"
 
   PHP_SUBST(ARCHIVE_SHARED_LIBADD)
-  PHP_NEW_EXTENSION(archive, libarchive.c stream.c, $ext_shared,,-Wall)
+  PHP_NEW_EXTENSION(archive, libarchive.c stream.c, $ext_shared,,$extra_cflags)
 fi

--- a/libarchive.c
+++ b/libarchive.c
@@ -30,6 +30,9 @@ static PHP_MINFO_FUNCTION(libarchive)
 {
     php_info_print_table_start();
     php_info_print_table_header(2, "libarchive support", "enabled");
+    php_info_print_table_row(2, "archive extension version", PHP_LIBARCHIVE_VERSION);
+    php_info_print_table_row(2, "libarchive version", ARCHIVE_VERSION_ONLY_STRING);
+    php_info_print_table_row(2, "libarchive details", archive_version_details());
     php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
1st commit simplify config.m4
2nd commit add useful information in phpinfo (for users support)

```
$ php -n -d extension=modules/archive.so --ri libarchive

libarchive

libarchive support => enabled
archive extension version => 0.1.0
libarchive version => 3.5.0
libarchive details => libarchive 3.5.0 zlib/1.2.11 liblzma/5.2.5 bz2lib/1.0.8 liblz4/1.9.1 libzstd/1.4.5
```
